### PR TITLE
integrate ant build system with github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,20 @@
+name: Java CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+
+      - run: ant -noinput -buildfile build.xml dist
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Package
+          path: dist/lib

--- a/build.xml
+++ b/build.xml
@@ -20,7 +20,7 @@
 
    <target name="path">
       <echo message="${toString:classpath.base}"/>
-   </target> 
+   </target>
 
     <target name="compile" depends="init"
           description="compile the source">
@@ -47,7 +47,7 @@
             <attribute name="Main-Class" value="BSPackage.BattleshipMain" />
         </manifest>
         <mkdir dir="${dist}/lib" />
-        <jar jarfile="${dist}/lib/project.jar" basedir="${build}" manifest ="build/MANIFEST.MF" />
+        <jar jarfile="${dist}/lib/BattleShip.jar" basedir="${build}" manifest ="build/MANIFEST.MF" />
     </target>
 
     <target name="run" depends="compile">
@@ -59,7 +59,7 @@
     </target>
 
     <target name="runjar" depends="dist">
-        <java jar="${dist}/lib/project.jar" fork="true" />
+        <java jar="${dist}/lib/BattleShip.jar" fork="true" />
     </target>
 
 </project>


### PR DESCRIPTION
On a new push to the repository, GitHub spins up a VM to build the `.jar` binary for users to download and run without having to compile themselves.